### PR TITLE
[Patch] Invoice number hook civicrm core 6.17.3

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -330,7 +330,13 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       }
       if (!$contribution->invoice_number) {
         // @todo - use {contribution.invoice_number token in the template}. remove this code.
-        $contribution->invoice_number = CRM_Contribute_BAO_Contribution::getInvoiceNumber($contribution->id);
+        // $contribution->invoice_number = CRM_Contribute_BAO_Contribution::getInvoiceNumber($contribution->id);
+        $invoice_number = CRM_Contribute_BAO_Contribution::getInvoiceNumber($contribution->id);
+        CRM_Utils_Hook::invoiceNumber($invoice_number, $contribution);
+        $contribution->invoice_number = $invoice_number;
+        // keep invoice_number and invoice_id identical:
+        $contribution->invoice_id = $invoice_number;
+
       }
 
       //to obtain due date for PDF invoice
@@ -419,6 +425,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       if (isset($creditNoteId)) {
         $tplParams['creditnote_id'] = $creditNoteId;
       }
+
+      // call the hook in case anyone has anything to add to those
+      CRM_Utils_Hook::invoiceParams($tplParams, $contribution);
 
       $pdfFileName = $contribution->invoice_number . ".pdf";
       $sendTemplateParams = [

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3295,4 +3295,36 @@ abstract class CRM_Utils_Hook {
     return self::singleton()->invoke(['filter'], $filter, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_relativeDate');
   }
 
+  /**
+   * This hook allows you to modify the invoice number as generate by the invoicing task
+   *
+   * @param string $invoice_id
+   *   The currently calculated invoice id
+   * @param object $contributionBAO
+   *   A BAO of the related contribution
+   *
+   * @return null
+   *   the return value is ignored
+   */
+  public static function invoiceNumber(&$invoice_id, $contributionBAO) {
+    $names = ['invoice_id', 'contributionBAO'];
+    return self::singleton()->invoke($names, $invoice_id, $contributionBAO, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_invoiceNumber');
+  }
+
+  /**
+   * This hook allows you modify/extend the smarty variables that
+   *  are being passed to the template in the invoice generation
+   *
+   * @param array $tplParams
+   *   All currently available variable
+   * @param object $contributionBAO
+   *   A BAO of the related contribution
+   *
+   * @return null
+   *   the return value is ignored
+   */
+  public static function invoiceParams(&$tplParams, $contributionBAO) {
+    $names = ['tplParams', 'contributionBAO'];
+    return self::singleton()->invoke($names, $tplParams, $contributionBAO, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_invoiceParams');
+  }
 }


### PR DESCRIPTION
use extra hooks for invoice number generation during invoice generation as pdf
- CRM_Utils_Hook::invoiceNumber
- CRM_Utils_Hook::invoiceParams

this patch is compatible with civicrm-core 6.17.3 and upwards.